### PR TITLE
Improve error msg output

### DIFF
--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -676,6 +676,8 @@ maybe_send_data(Bytes, IsFin, StreamRef,
             Stream#{sendbuff := IolistData, sendbuff_size := IolistSize}
     end.
 
+trailers_to_error([]) ->
+    stream_closed_without_any_response;
 trailers_to_error(Trailers) ->
     {grpc_utils:codename(
        proplists:get_value(<<"grpc-status">>, Trailers, ?GRPC_STATUS_OK)

--- a/src/grpc.app.src
+++ b/src/grpc.app.src
@@ -1,7 +1,7 @@
 %% -*- mode: erlang -*-
 {application, grpc,
  [{description, "An Erlang implementation of gRPC"},
-  {vsn, "0.6.7"},
+  {vsn, "0.6.8"},
   {registered, []},
   {mod, {grpc_app, []}},
   {applications, [kernel,stdlib,gproc,cowboy,gun]},

--- a/src/grpc.appup.src
+++ b/src/grpc.appup.src
@@ -1,6 +1,8 @@
 %% -*- mode: erlang -*-
-{"0.6.7",
- [{"0.6.6",
+{"0.6.8",
+ [{"0.6.7",
+   [{load_module, grpc_client, brutal_purge, soft_purge, []}]},
+  {"0.6.6",
    [{update, grpc_client, {advanced, ["0.6.6"]}}]},
   {"0.6.5",
    [{update, grpc_client, {advanced, ["0.6.5"]}}]},
@@ -17,7 +19,9 @@
     {load_module, grpc_client_sup, brutal_purge, soft_purge, []}]},
   {<<".*">>, []}
   ],
- [{"0.6.6",
+ [{"0.6.7",
+   [{load_module, grpc_client, brutal_purge, soft_purge, []}]},
+  {"0.6.6",
    [{update, grpc_client, {advanced, ["0.6.6"]}}]},
   {"0.6.5",
    [{update, grpc_client, {advanced, ["0.6.5"]}}]},

--- a/src/grpc.appup.src
+++ b/src/grpc.appup.src
@@ -5,7 +5,7 @@
   {"0.6.5",
    [{update, grpc_client, {advanced, ["0.6.5"]}}]},
   {"0.6.4",
-   [{update, grpc_client, {advanced, ["0.6.4"]}}
+   [{update, grpc_client, {advanced, ["0.6.4"]}},
     {load_module, grpc_client_sup, brutal_purge, soft_purge, []}]},
   {"0.6.3",
    [{update, grpc_client, {advanced, ["0.6.3"]}},
@@ -22,7 +22,7 @@
   {"0.6.5",
    [{update, grpc_client, {advanced, ["0.6.5"]}}]},
   {"0.6.4",
-   [{update, grpc_client, {advanced, ["0.6.4"]}}
+   [{update, grpc_client, {advanced, ["0.6.4"]}},
     {load_module, grpc_client_sup, brutal_purge, soft_purge, []}]},
   {"0.6.3",
    [{update, grpc_client, {advanced, ["0.6.3"]}},


### PR DESCRIPTION
Closes https://askemq.com/t/topic/4253

If the HTTP/2 stream closed without any response or trailers, the `grpc_clieint:unary/4` will return `{error, {ok, <<>>}}`. It's a  strange error reason. So we change it to `stream_closed_without_any_response`