### PR TITLE
fix(client): correct the gun_response handling

### DIFF
--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -509,10 +509,14 @@ stream_handle({read, From, _StreamRef, _EndTs},
 
 %% gun msgs
 
-stream_handle({gun_response, _GunPid, _StreamRef, nofin, _Status, _Headers},
+stream_handle({gun_response, _GunPid, _StreamRef, IsFin, _Status, Headers},
               Stream = #{st := {_LS, idle}}) ->
-    %% TODO: error handling?
-    {ok, Stream#{st => {_LS, open}}};
+    case IsFin of
+        nofin ->
+            {ok, Stream#{st => {_LS, open}}};
+        fin ->
+            handle_remote_closed(Headers, Stream)
+    end;
 
 stream_handle({gun_trailers, _GunPid, _StreamRef, Trailers},
               Stream = #{st := {_LS, open}}) ->

--- a/src/grpc.erl
+++ b/src/grpc.erl
@@ -110,7 +110,7 @@ compile_service_rules(Services0) ->
         end
     end, #{}, Services).
 
--spec stop_server(any()) -> ok | {error, term()}.
+-spec stop_server(any()) -> ok | {error, not_found}.
 
 %% @doc Stop a gRPC server
 stop_server(Name) ->


### PR DESCRIPTION
Before this fix, the following logs will be printed if the grpc server return `fin` flags in HTTP2 Header

```
2023-05-17T14:23:47.726580+08:00 [error] Unexecpted stream event: {gun_response,<0.3131.0>,#Ref<0.3512757049.3783262220.109807>,fin,200,[{<<"content-type">>,<<"application/grpc">>},{<<"grpc-status">>,<<"2">>}]}, stream #{encoding => identity,hangs => [{{<0.3186.0>,#Ref<0.3512757049.3783262220.109810>},infinity}],mqueue => [],recvbuff => <<>>,sendbuff => [],sendbuff_last_flush_ts => 0,sendbuff_size => 0,st => {closed,idle}}

```