### PR TITLE
fix: fix message loss on server stream reset

### DIFF
--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -504,6 +504,10 @@ stream_handle({read, From, _StreamRef, _EndTs},
     {ok, [{reply, From, {ok, MQueue}}], Stream#{mqueue => []}};
 
 stream_handle({read, From, _StreamRef, _EndTs},
+    Stream = #{st := {_LS, closed}, mqueue := MQueue}) when MQueue /= [] ->
+    {shutdown, normal, [{reply, From, {ok, MQueue}}], Stream#{mqueue => []}};
+
+stream_handle({read, From, _StreamRef, _EndTs},
               Stream = #{st := {closed, closed}, mqueue := MQueue}) ->
     {shutdown, normal, [{reply, From, {ok, MQueue}}], Stream#{mqueue => []}};
 
@@ -552,6 +556,9 @@ stream_handle({gun_data, _GunPid, _StreamRef, fin, Data},
             handle_remote_closed([], Stream#{recvbuff => <<>>, mqueue => MQueue ++ Frames})
     end;
 
+stream_handle({gun_error, _GunPid, _StreamRef, {stream_error, no_error, 'Stream reset by server.'}},
+              Stream = #{st := {_LS, closed}, mqueue := MQueue}) when MQueue =/= [] ->
+    {ok, Stream};
 stream_handle({gun_error, _GunPid, _StreamRef, Reason}, Stream) ->
     {shutdown, Reason, Stream};
 

--- a/test/route_guide.proto
+++ b/test/route_guide.proto
@@ -98,11 +98,13 @@ message Feature {
 
 // A RouteNote is a message sent while at a given point.
 message RouteNote {
+  string name = 1;
+
   // The location from which the message is sent.
-  Point location = 1;
+  Point location = 2;
 
   // The message to be sent.
-  string message = 2;
+  string message = 3;
 }
 
 // A RouteSummary is received in response to a RecordRoute rpc.

--- a/test/route_guide_svr.erl
+++ b/test/route_guide_svr.erl
@@ -58,16 +58,5 @@ record_route(Stream, _Md) ->
 route_chat(Stream, _Md) ->
     grpc_stream:reply(Stream, [#{name => "City1", location => #{latitude => 1, longitude => 1}}]),
     grpc_stream:reply(Stream, [#{name => "City2", location => #{latitude => 2, longitude => 2}}]),
-    LoopRecv = fun _Lp(St) ->
-        case grpc_stream:recv(St) of
-            {more, Reqs, NSt} ->
-                ?LOG("~p: ~0p~n", [?FUNCTION_NAME, Reqs]),
-                _Lp(NSt);
-            {eos, Reqs, NSt} ->
-                ?LOG("~p: ~0p~n", [?FUNCTION_NAME, Reqs]),
-                NSt
-        end
-    end,
-    NStream = LoopRecv(Stream),
-    grpc_stream:reply(NStream, [#{name => "City3", location => #{latitude => 3, longitude => 3}}]),
-    {ok, NStream}.
+    grpc_stream:reply(Stream, [#{name => "City3", location => #{latitude => 3, longitude => 3}}]),
+    {ok, Stream}.


### PR DESCRIPTION
Fixes [EMQX-10655](https://emqx.atlassian.net/browse/EMQX-10655)

GRPC client has the following issue with stream ↔︎ stream rpc: 

- a client opens a stream and sends a request (send) without fin
- server sends some records
- server closes stream (eos)
- server closes http2 stream
- grpc_client drops the stream because of http2 close (on gun_error message)
- client sends recv
- the stream is not found, the client never receives the sent records, they are lost. client receives not_found error.

- [x] test added