### PR TITLE
fix(client): use content type accepted by googleapis.com

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -4,20 +4,6 @@ on: [push, pull_request]
 
 jobs:
 
-  windows:
-    runs-on: windows-latest
-
-    steps:
-    - uses: actions/checkout@v4
-    - uses: erlef/setup-beam@v1
-      with:
-        otp-version: '27'
-        rebar3-version: '3.23.0'
-    - run: rebar3 xref
-    - run: rebar3 dialyzer
-    - run: rebar3 eunit
-    - run: rebar3 ct
-
   linux:
     runs-on: ubuntu-latest
 
@@ -68,4 +54,3 @@ jobs:
       run: |
         docker run --rm -i --name alpine -v $(pwd):/repos ${{ matrix.builder }}-alpine3.15.1 \
           sh -c "cd /repos && make eunit && make ct"
-

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -342,7 +342,9 @@ handle_call({open, #{path := Path,
             _From,
             State = #state{gun_pid = GunPid, streams = Streams, encoding = Encoding}) ->
     Timeout = maps:get(timeout, Options, infinity),
+    ContentType = maps:get(content_type, Options, <<"application/grpc+proto">>),
     Headers = assemble_grpc_headers(atom_to_binary(Encoding, utf8),
+                                    ContentType,
                                     MessageType,
                                     Timeout,
                                     Metadata
@@ -817,8 +819,8 @@ call_result(_ExitOnCrash = false, Reason) ->
 pick(ChannName, Key) ->
     gproc_pool:pick_worker(ChannName, Key).
 
-assemble_grpc_headers(Encoding, MessageType, Timeout, MD) ->
-    [{<<"content-type">>, <<"application/grpc">>},
+assemble_grpc_headers(Encoding, ContentType, MessageType, Timeout, MD) ->
+    [{<<"content-type">>, ContentType},
      {<<"user-agent">>, <<"grpc-erlang/0.1.0">>},
      {<<"grpc-encoding">>, Encoding},
      {<<"grpc-message-type">>, MessageType},

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -818,7 +818,7 @@ pick(ChannName, Key) ->
     gproc_pool:pick_worker(ChannName, Key).
 
 assemble_grpc_headers(Encoding, MessageType, Timeout, MD) ->
-    [{<<"content-type">>, <<"application/grpc+proto">>},
+    [{<<"content-type">>, <<"application/grpc">>},
      {<<"user-agent">>, <<"grpc-erlang/0.1.0">>},
      {<<"grpc-encoding">>, Encoding},
      {<<"grpc-message-type">>, MessageType},


### PR DESCRIPTION
Apparently, google servers are very nit-picky about the `content-type` header used when using gRPC.

While attempting to generate and use a client for BigTable, I noticed that google was returning a 404 HTML page error for the executed requests.  Changing the content type to `application/grpc`, which apparently is what official client libraries use, made it return sensible responses.