### PR TITLE
fix: avoid leaking gun processes when reconnecting

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {deps,
  [ {gpb, "~> 4.21"}
  , {gproc, "1.0.0"}
- , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
+ , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.13.0-emqx-3"}}}
  , {gun, "2.1.0"}
  ]}.
 

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -675,7 +675,8 @@ clean_hangs(Stream = #{hangs := Hangs}) ->
 %% Internal funcs
 %%--------------------------------------------------------------------
 
-do_connect(State = #state{server = {_, Host, Port}, client_opts = ClientOpts}) ->
+do_connect(State0 = #state{server = {_, Host, Port}, client_opts = ClientOpts}) ->
+    State = ensure_gun_stopped(State0),
     GunOpts = maps:get(gun_opts, ClientOpts, #{}),
     case gun:open(Host, Port, GunOpts) of
         {ok, Pid} ->
@@ -696,6 +697,12 @@ do_connect(State = #state{server = {_, Host, Port}, client_opts = ClientOpts}) -
         {error, Reason} ->
             {error, Reason}
     end.
+
+ensure_gun_stopped(#state{gun_pid = Pid} = State0) when is_pid(Pid) ->
+    _ = gun:close(Pid),
+    State0#state{gun_pid = undefined};
+ensure_gun_stopped(#state{} = State0) ->
+    State0.
 
 %%--------------------------------------------------------------------
 %% Helpers

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -699,7 +699,17 @@ do_connect(State0 = #state{server = {_, Host, Port}, client_opts = ClientOpts}) 
     end.
 
 ensure_gun_stopped(#state{gun_pid = Pid} = State0) when is_pid(Pid) ->
+    MRef = monitor(process, Pid),
     _ = gun:close(Pid),
+    receive
+        {'DOWN', MRef, process, Pid, _} ->
+            ok
+    after
+        1_000 ->
+            exit(Pid, kill),
+            receive {'DOWN', MRef, process, Pid, _} -> ok end,
+            ok
+    end,
     State0#state{gun_pid = undefined};
 ensure_gun_stopped(#state{} = State0) ->
     State0.

--- a/test/grpc_SUITE.erl
+++ b/test/grpc_SUITE.erl
@@ -35,7 +35,14 @@ all() ->
     [{group, http}, {group, https}].
 
 groups() ->
-    Tests = [t_say_hello, t_get_feature, t_list_features, t_record_route, t_record_chat],
+    Tests = [
+        t_say_hello,
+        t_get_feature,
+        t_list_features,
+        t_record_route,
+        t_record_chat,
+        t_reconnect_no_gun_leak
+    ],
     [{http, Tests}, {https,Tests}].
 
 init_per_group(GrpName, Cfg) ->
@@ -71,7 +78,7 @@ init_per_group(GrpName, Cfg) ->
 
     {ok, _} = grpc:start_server(?SERVER_NAME, 10000, Services, Options),
     {ok, _} = grpc_client_sup:create_channel_pool(?CHANN_NAME, SvrAddr, ClientOps),
-    Cfg.
+    [{services, Services}, {server_opts, Options} | Cfg].
 
 end_per_group(_GrpName, _Cfg) ->
     _ = grpc_client_sup:stop_channel_pool(?CHANN_NAME),
@@ -123,6 +130,27 @@ t_record_chat(_) ->
         recv_n(Stream, 4)
     ).
 
+t_reconnect_no_gun_leak(TCConfig) ->
+    %% sanity check: we have some connections already.
+    PidsBefore = get_gun_pids(),
+    ?assertMatch([_ | _], PidsBefore),
+    Worker0 = gproc_pool:pick_worker(?CHANN_NAME, key),
+    ?assertMatch(ok, grpc_client:health_check(Worker0, #{connect_timeout => 100})),
+    %% make gun become disconnected
+    _ = grpc:stop_server(?SERVER_NAME),
+    ?assertMatch({error, _}, grpc_client:health_check(Worker0, #{connect_timeout => 100})),
+    %% reconnect
+    {services, Services} = lists:keyfind(services, 1, TCConfig),
+    {server_opts, Options} = lists:keyfind(server_opts, 1, TCConfig),
+    {ok, _} = grpc:start_server(?SERVER_NAME, 10000, Services, Options),
+    ?assertMatch(ok, grpc_client:health_check(Worker0, #{connect_timeout => 10_000})),
+    %% should not have leaked pids
+    PidsAfter = get_gun_pids(),
+    ?assertNot(length(PidsAfter) > length(PidsBefore), #{pids_before => PidsBefore,
+                                                         pids_after => PidsAfter,
+                                                         new_pids => PidsAfter -- PidsBefore}),
+    ok.
+
 %%--------------------------------------------------------------------
 %% Helper functions
 %%--------------------------------------------------------------------
@@ -135,3 +163,6 @@ recv_n(_Stream, 0, Acc) ->
 recv_n(Stream, N, Acc) ->
     {ok, Fs} = grpc_client:recv(Stream),
     recv_n(Stream, N - length(Fs), Acc ++ Fs).
+
+get_gun_pids() ->
+    [Pid || {_, Pid, _, _} <- supervisor:which_children(gun_conns_sup)].


### PR DESCRIPTION
Before this fix, a simple reconnect could potentially leak gun processes, which led to
repeated logs warning about it like:

```
2026-05-08T16:28:10.473434+00:00 [warning] [gRPC Client] Unexpected info: {gun_down,<0.5562.0>,http2,normal,[]}
2026-05-08T16:28:10.597745+00:00 [warning] [gRPC Client] Unexpected info: {gun_up,<0.5562.0>,http2}
```
