### PR TITLE
fix: reply callers before dropping streams, reduce log level of some events

### DIFF
--- a/.github/workflows/run_test_case.yaml
+++ b/.github/workflows/run_test_case.yaml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         builder:
           - ghcr.io/emqx/emqx-builder/5.4-3:1.17.3-27.2-1

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -554,9 +554,11 @@ handle_stream_handle_result({ok, Events, Stream}, StreamRef, Streams, State) ->
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State)
     when Reason =:= normal orelse ?IS_SILENCED_STREAM_ERROR(Reason) ->
     ?LOG(debug, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
+    reply_hangs(Stream, {error, Reason}),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State) ->
     ?LOG(error, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
+    reply_hangs(Stream, {error, Reason}),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 % self-induced shutdown
 handle_stream_handle_result({shutdown, Reason, Events, _Stream}, StreamRef, Streams, State) ->
@@ -675,6 +677,11 @@ clean_hangs(Stream = #{hangs := Hangs}) ->
     Nowts = erlang:system_time(millisecond),
     Hangs1 = lists:filter(fun({_, T}) -> T >= Nowts end, Hangs),
     Stream#{hangs => Hangs1}.
+
+%% if there are any calls waiting on us, we must reply them.
+reply_hangs(DroppedStream, Result) ->
+    #{hangs := Hangs} = DroppedStream,
+    lists:foreach(fun({From, _EndTs}) -> gen_server:reply(From, Result) end, Hangs).
 
 %%--------------------------------------------------------------------
 %% Internal funcs

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -140,7 +140,8 @@
 -define(DEFAULT_STREAMING_BATCH_SIZE, 16384).
 
 -define(IS_SILENCED_STREAM_ERROR(ERR),
-    ((ERR) =:= {stream_error,no_error,'Stream reset by server.'} orelse
+    ((ERR) =:= normal orelse
+     (ERR) =:= {stream_error,no_error,'Stream reset by server.'} orelse
      (ERR) =:= {stream_error,refused_stream,'Stream reset by server.'} orelse
      (ERR) =:= {closed,{error,closed}} orelse
      (ERR) =:= closed orelse
@@ -563,7 +564,7 @@ handle_stream_handle_result({ok, Events, Stream}, StreamRef, Streams, State) ->
     {noreply, State#state{streams = Streams#{StreamRef => Stream}}};
 % shutdown on gun error
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State)
-    when Reason =:= normal orelse ?IS_SILENCED_STREAM_ERROR(Reason) ->
+    when ?IS_SILENCED_STREAM_ERROR(Reason) ->
     ?LOG(debug, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
     reply_hangs(Stream, {error, Reason}),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
@@ -573,7 +574,7 @@ handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, Stat
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 % self-induced shutdown
 handle_stream_handle_result({shutdown, Reason, Events, _Stream}, StreamRef, Streams, State) ->
-    (Reason /= normal andalso not ?IS_SILENCED_STREAM_ERROR(Reason)) andalso
+    ?IS_SILENCED_STREAM_ERROR(Reason) orelse
         ?LOG(error, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s",
              [Reason, format_stream(_Stream)]),
     _ = run_events(Events),

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -713,16 +713,18 @@ do_connect(State0 = #state{server = {_, Host, Port}, client_opts = ClientOpts}) 
                 {ok, _Protocol} ->
                     State#state{mref = MRef, gun_pid = Pid, gun_state = up};
                 {error, {down, Reason}} ->
+                    demonitor(MRef, [flush]),
                     {error, Reason};
                 {error, timeout} ->
                     _ = gun:close(Pid),
+                    demonitor(MRef, [flush]),
                     {error, timeout}
             end;
         {error, Reason} ->
             {error, Reason}
     end.
 
-ensure_gun_stopped(#state{gun_pid = Pid} = State0) when is_pid(Pid) ->
+ensure_gun_stopped(#state{mref = OldMRef, gun_pid = Pid} = State0) when is_pid(Pid) ->
     MRef = monitor(process, Pid),
     _ = gun:close(Pid),
     receive
@@ -734,7 +736,8 @@ ensure_gun_stopped(#state{gun_pid = Pid} = State0) when is_pid(Pid) ->
             receive {'DOWN', MRef, process, Pid, _} -> ok end,
             ok
     end,
-    State0#state{gun_pid = undefined};
+    is_reference(OldMRef) andalso demonitor(OldMRef, [flush]),
+    State0#state{mref = undefined, gun_pid = undefined};
 ensure_gun_stopped(#state{} = State0) ->
     State0.
 

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -141,7 +141,10 @@
 
 -define(IS_SILENCED_STREAM_ERROR(ERR),
     ((ERR) =:= {stream_error,no_error,'Stream reset by server.'} orelse
-     (ERR) =:= {stream_error,refused_stream,'Stream reset by server.'})
+     (ERR) =:= {stream_error,refused_stream,'Stream reset by server.'} orelse
+     (ERR) =:= {closed,{error,closed}} orelse
+     (ERR) =:= closed orelse
+     (ERR) =:= {goaway,protocol_error,'The connection is going away.'})
 ).
 
 -type stream_state() :: idle | open | closed.
@@ -477,7 +480,8 @@ handle_info(Info, State = #state{streams = Streams}) when is_tuple(Info) ->
                 _ ->
                     case maps:get(StreamRef, Streams, undefined) of
                         undefined ->
-                            ?LOG(warning, "[gRPC Client] Unknown stream ref: ~0p, "
+                            LogLevel = unknown_stream_ref_log_level(Info),
+                            ?LOG(LogLevel, "[gRPC Client] Unknown stream ref: ~0p, "
                                           "event: ~0p", [StreamRef, Info]),
                             {noreply, State};
                         Stream ->
@@ -492,6 +496,13 @@ handle_info(Info, State = #state{streams = Streams}) when is_tuple(Info) ->
             ?LOG(warning, "[gRPC Client] Unexpected info: ~p~n", [Info]),
             {noreply, State}
     end.
+
+unknown_stream_ref_log_level({gun_error, _, _, {stream_error,no_error,'Stream reset by server.'}}) ->
+    debug;
+unknown_stream_ref_log_level({gun_error, _, _, {closed,{error,closed}}}) ->
+    debug;
+unknown_stream_ref_log_level(_) ->
+    warning.
 
 terminate(_Reason, #state{pool = Pool, id = Id}) ->
     gproc_pool:disconnect_worker(Pool, {Pool, Id}).

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -139,6 +139,11 @@
 -define(DEFAULT_STREAMING_DELAY, 20).
 -define(DEFAULT_STREAMING_BATCH_SIZE, 16384).
 
+-define(IS_SILENCED_STREAM_ERROR(ERR),
+    ((ERR) =:= {stream_error,no_error,'Stream reset by server.'} orelse
+     (ERR) =:= {stream_error,refused_stream,'Stream reset by server.'})
+).
+
 -type stream_state() :: idle | open | closed.
 
 -type stream() :: #{ st       := {LocalState :: stream_state(),
@@ -547,17 +552,17 @@ handle_stream_handle_result({ok, Events, Stream}, StreamRef, Streams, State) ->
     {noreply, State#state{streams = Streams#{StreamRef => Stream}}};
 % shutdown on gun error
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State)
-    when Reason =:= normal orelse Reason =:= {stream_error,no_error,'Stream reset by server.'} ->
+    when Reason =:= normal orelse ?IS_SILENCED_STREAM_ERROR(Reason) ->
     ?LOG(debug, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State) ->
     ?LOG(error, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 % self-induced shutdown
-handle_stream_handle_result({shutdown, _Reason, Events, _Stream}, StreamRef, Streams, State) ->
-    _Reason /= normal andalso
+handle_stream_handle_result({shutdown, Reason, Events, _Stream}, StreamRef, Streams, State) ->
+    (Reason /= normal andalso not ?IS_SILENCED_STREAM_ERROR(Reason)) andalso
         ?LOG(error, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s",
-             [_Reason, format_stream(_Stream)]),
+             [Reason, format_stream(_Stream)]),
     _ = run_events(Events),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}}.
 

--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -563,13 +563,13 @@ handle_stream_handle_result({ok, Events, Stream}, StreamRef, Streams, State) ->
     _ = run_events(Events),
     {noreply, State#state{streams = Streams#{StreamRef => Stream}}};
 % shutdown on gun error
-handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State)
-    when ?IS_SILENCED_STREAM_ERROR(Reason) ->
-    ?LOG(debug, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
-    reply_hangs(Stream, {error, Reason}),
-    {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 handle_stream_handle_result({shutdown, Reason, Stream}, StreamRef, Streams, State) ->
-    ?LOG(error, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
+    LogLevel =
+        case ?IS_SILENCED_STREAM_ERROR(Reason) of
+            true -> debug;
+            false -> warning
+        end,
+    ?LOG(LogLevel, "[gRPC Client] Stream shutdown reason: ~p, stream: ~s", [Reason, format_stream(Stream)]),
     reply_hangs(Stream, {error, Reason}),
     {noreply, State#state{streams = maps:remove(StreamRef, Streams)}};
 % self-induced shutdown


### PR DESCRIPTION
```
2026-05-08T20:32:09.210024+00:00 [error] [gRPC Client] Stream shutdown reason: {stream_error,refused_stream,'Stream reset by server.'}, stream: #stream{st={open,idle}, buff_size=0, mqueue=[]}
```