### PR TITLE
fix(client): lower unknown stream log level to debug

### DIFF
--- a/src/client/grpc_client.erl
+++ b/src/client/grpc_client.erl
@@ -597,6 +597,8 @@ unknown_stream_ref_log_level({gun_error, _, _, {stream_error,no_error,'Stream re
     debug;
 unknown_stream_ref_log_level({gun_error, _, _, {closed,{error,closed}}}) ->
     debug;
+unknown_stream_ref_log_level({gun_error, _, _, {badstate,"The stream cannot be found."}}) ->
+    debug;
 unknown_stream_ref_log_level(_) ->
     warning.
 


### PR DESCRIPTION
When cancelling streams, there are races that can cause `{gun_error, _, _, {badstate,"The stream cannot be found."}}` to be received, which in this case are harmless.